### PR TITLE
Remove alias usage

### DIFF
--- a/AU.psm1
+++ b/AU.psm1
@@ -1,10 +1,10 @@
 # Export functions that start with capital letter, others are private
 # Include file names that start with capital letters, ignore others
 
-$pre = ls Function:\*
-ls "$PSScriptRoot\*.ps1" | ? { $_.Name -cmatch '^[A-Z]+' } | % { . $_  }
-$post = ls Function:\*
-$funcs = compare $pre $post | select -Expand InputObject | select -Expand Name
-$funcs | ? { $_ -cmatch '^[A-Z]+'} | % { Export-ModuleMember -Function $_ }
+$pre = Get-ChildItem Function:\*
+Get-ChildItem "$PSScriptRoot\*.ps1" | Where-Object { $_.Name -cmatch '^[A-Z]+' } | ForEach-Object { . $_  }
+$post = Get-ChildItem Function:\*
+$funcs = Compare-Object $pre $post | Select-Object -Expand InputObject | Select-Object -Expand Name
+$funcs | Where-Object { $_ -cmatch '^[A-Z]+'} | ForEach-Object { Export-ModuleMember -Function $_ }
 
 Export-ModuleMember -Alias *

--- a/Get-AUPackages.ps1
+++ b/Get-AUPackages.ps1
@@ -15,8 +15,8 @@
 #>
 
 function Get-AUPackages($Name=$null) {
-    ls .\*\update.ps1 | % {
-        $packageDir = gi (Split-Path $_)
+    Get-ChildItem .\*\update.ps1 | ForEach-Object {
+        $packageDir = Get-Item (Split-Path $_)
         if ($packageDir.Name -like '_*') { return }
         if ($Name) {
             if ( $packageDir.Name -like "$Name" ) { $packageDir }

--- a/Push-Package.ps1
+++ b/Push-Package.ps1
@@ -1,9 +1,9 @@
 function Push-Package() {
-    $api_key =  if (Test-Path api_key) { gc api_key }
-                elseif (Test-Path ..\api_key) { gc ..\api_key }
+    $api_key =  if (Test-Path api_key) { Get-Content api_key }
+                elseif (Test-Path ..\api_key) { Get-Content ..\api_key }
                 elseif ($Env:api_key) { $Env:api_key }
 
-    $package = ls *.nupkg | sort -Property CreationTime -Descending | select -First 1
+    $package = Get-ChildItem *.nupkg | Sort-Object -Property CreationTime -Descending | Select-Object -First 1
     if (!$package) { throw 'There is no nupkg file in the directory'}
     if ($api_key) {
         cpush $package.Name --api-key $api_key

--- a/Test-Package.ps1
+++ b/Test-Package.ps1
@@ -1,7 +1,7 @@
 function Test-Package() {
     choco pack
 
-    $package_file    = gi *.nupkg | sort -Property CreationTime -Descending | select -First 1
+    $package_file    = Get-Item *.nupkg | Sort-Object -Property CreationTime -Descending | Select-Object -First 1
     $package_name    = $package_file.Name  -replace '(\.\d+)+\.nupkg$'
     $package_version = ($package_file.BaseName -replace $package_name).Substring(1)
 


### PR DESCRIPTION
Users can redefine or remove aliases, making the script brittle

As an example, I redefine `rm` to a version that deletes to the recycle bin, which caused AU to fail (because it doesn't accept `-Force`).