### PR TITLE
Add additional properties in Get-RemoteFiles

### DIFF
--- a/AU/Public/Get-RemoteFiles.ps1
+++ b/AU/Public/Get-RemoteFiles.ps1
@@ -62,6 +62,7 @@ function Get-RemoteFiles {
             Write-Host "Downloading to $file_name -" $Latest.Url32
             $client.DownloadFile($Latest.URL32, $file_path)
             $global:Latest.Checksum32 = Get-FileHash $file_path | % Hash
+            $global:Latest.FileName32 = $file_name
         }
 
         if ($Latest.Url64) {
@@ -72,6 +73,7 @@ function Get-RemoteFiles {
             Write-Host "Downloading to $file_name -" $Latest.Url64
             $client.DownloadFile($Latest.URL64, $file_path)
             $global:Latest.Checksum64 = Get-FileHash $file_path | % Hash
+            $global:Latest.FileName64 = $file_name
         }
     } catch{ throw $_ } finally { $client.Dispose() }
 }

--- a/AU/Public/Get-RemoteFiles.ps1
+++ b/AU/Public/Get-RemoteFiles.ps1
@@ -27,7 +27,12 @@ function Get-RemoteFiles {
 
         # By default last URL part is used as a file name. Use this paramter to skip parts 
         # if file name is specified earlier in the path.
-        [int]    $FileNameSkip=0
+        [int]    $FileNameSkip=0,
+
+        # Sets the algorithm to use when calculating checksums
+        # This defaults to sha256
+        [ValidateSet('md5','sha1','sha256','sha384','sha512')]
+        [string] $Algorithm = 'sha256'
     )
 
     function name4url($url) {
@@ -61,7 +66,8 @@ function Get-RemoteFiles {
 
             Write-Host "Downloading to $file_name -" $Latest.Url32
             $client.DownloadFile($Latest.URL32, $file_path)
-            $global:Latest.Checksum32 = Get-FileHash $file_path | % Hash
+            $global:Latest.Checksum32 = Get-FileHash $file_path -Algorithm $Algorithm | % Hash
+            $global:Latest.ChecksumType32 = $Algorithm
             $global:Latest.FileName32 = $file_name
         }
 
@@ -72,7 +78,8 @@ function Get-RemoteFiles {
 
             Write-Host "Downloading to $file_name -" $Latest.Url64
             $client.DownloadFile($Latest.URL64, $file_path)
-            $global:Latest.Checksum64 = Get-FileHash $file_path | % Hash
+            $global:Latest.Checksum64 = Get-FileHash $file_path -Algorithm $Algorithm | % Hash
+            $global:Latest.ChecksumType32 = $Algorithm
             $global:Latest.FileName64 = $file_name
         }
     } catch{ throw $_ } finally { $client.Dispose() }


### PR DESCRIPTION
This PR sets the following properties in `$global:Latest`
If `URL32` is set, it then sets the resolved file name as `FileName32`, also sets `ChecksumType32` to the specified Algorithm passed as a parameter.
If URL64 is set, it then sets the resolved file name as `FileName64`, also sets `ChecksumType64` to the specified Algorithm passed as a parameter.