### PR TITLE
Use Latest.PackageName instead of $package.Name

### DIFF
--- a/AU/Public/Update-Package.ps1
+++ b/AU/Public/Update-Package.ps1
@@ -331,7 +331,7 @@ function Update-Package {
 
     if (is_updated) {
         if (!($NoCheckChocoVersion -or $Force)) {
-            $choco_url = "https://chocolatey.org/packages/{0}/{1}" -f $package.Name, $package.RemoteVersion
+            $choco_url = "https://chocolatey.org/packages/{0}/{1}" -f $global:Latest.PackageName, $package.RemoteVersion
             try {
                 request $choco_url $Timeout | out-null
                 "New version is available but it already exists in the Chocolatey community feed (disable using `$NoCheckChocoVersion`):`n  $choco_url" | result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bugfixes
 
 - Fix ps1 files encoded in UTF8 without BOM being treated as ANSI. 
+- Fix chocolatey.org package check using wrong package name when overridden in update.ps1.
 
 ## 2017.1.14
 


### PR DESCRIPTION
When using package.Name instead of Latest.PackageName disables
the possibility to check if the package+version already exists
on chocolatey.org if the package overrides the PackageName.
This commit fixes that by using Latest.PackageName.

fixes #67