### PR TITLE
Don't require nuspec name to match directory name

### DIFF
--- a/AU/Private/AUPackage.ps1
+++ b/AU/Private/AUPackage.ps1
@@ -14,11 +14,12 @@ class AUPackage {
         if ([String]::IsNullOrWhiteSpace( $Path )) { throw 'Package path can not be empty' }
 
         $this.Path = $Path
-        $this.Name = Split-Path -Leaf $Path
 
-        $this.NuspecPath = '{0}\{1}.nuspec' -f $this.Path, $this.Name
-        if (!(gi $this.NuspecPath -ea ignore)) { throw 'No nuspec file found in the package directory' }
+        $nuspecFile = gi "$Path\*.nuspec" -ea ignore
+        if (!($nuspecFile)) { throw 'No nuspec file found in the package directory' }
 
+        $this.NuspecPath = $nuspecFile.FullName
+        $this.Name = Split-Path -Leaf $this.NuspecPath
         $this.NuspecXml     = [AUPackage]::LoadNuspecFile( $this.NuspecPath )
         $this.NuspecVersion = $this.NuspecXml.package.metadata.version
     }

--- a/AU/Private/AUPackage.ps1
+++ b/AU/Private/AUPackage.ps1
@@ -18,8 +18,8 @@ class AUPackage {
         $nuspecFile = gi "$Path\*.nuspec" -ea ignore
         if (!($nuspecFile)) { throw 'No nuspec file found in the package directory' }
 
-        $this.NuspecPath = $nuspecFile.FullName
-        $this.Name = Split-Path -Leaf $this.NuspecPath
+        $this.Name          = $nuspecFile.BaseName
+        $this.NuspecPath    = $nuspecFile.FullName
         $this.NuspecXml     = [AUPackage]::LoadNuspecFile( $this.NuspecPath )
         $this.NuspecVersion = $this.NuspecXml.package.metadata.version
     }


### PR DESCRIPTION
My scenario is that I have multiple folders for the same package (beta or legacy versions), so I can't use the same folder name as the package for all of them.

Hope it helps. Thanks!