### PR TITLE
Remove aliases

### DIFF
--- a/AU/AU.psm1
+++ b/AU/AU.psm1
@@ -2,5 +2,5 @@
 
 $paths = "Private", "Public"
 foreach ($path in $paths) {
-    ls $PSScriptRoot\$path\*.ps1 | % { . $_ }
+    Get-ChildItem $PSScriptRoot\$path\*.ps1 | foreach { . $_ }
 }


### PR DESCRIPTION
If the alias 'ls' is mapped to something other than Get-ChildItem then nothing is imported. It's bad practice to use aliases in modules for this reason so the PR is to remove them.