### PR TITLE
Fix readme about Invoke Web Request statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ As an example, the following function uses [Invoke-WebRequest](https://technet.m
 
 ```powershell
 function global:au_GetLatest {
-     $download_page = Invoke-WebRequest -Uri $releases #1 
+     $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing #1
      $regex   = '.exe$'
      $url     = $download_page.links | ? href -match $regex | select -First 1 -expand href #2
      $version = $url -split '-|.exe' | select -Last 1 -Skip 2 #3


### PR DESCRIPTION
The Invoke web request cmdlet is failing if Internet Explorer hasn't
been loaded at least one time.
Using New-Object System.Net.WebClient might be an option as well.