### PR TITLE
push-package: add the ability to use simple server publishing

### DIFF
--- a/AU/Public/Push-Package.ps1
+++ b/AU/Public/Push-Package.ps1
@@ -10,15 +10,27 @@
     or cached nuget API key.
 #>
 function Push-Package() {
-    $api_key =  if (Test-Path api_key) { gc api_key }
-                elseif (Test-Path ..\api_key) { gc ..\api_key }
-                elseif ($Env:api_key) { $Env:api_key }
-
+    
     $package = ls *.nupkg | sort -Property CreationTime -Descending | select -First 1
     if (!$package) { throw 'There is no nupkg file in the directory'}
-    if ($api_key) {
-        cpush $package.Name --api-key $api_key --source https://push.chocolatey.org 
-    } else {
-        cpush $package.Name --source https://push.chocolatey.org 
+
+    if ($env:au_SimpleServerPath) {
+      try {
+        Move-Item $package.Name $env:au_SimpleServerPath -ea Stop
+      }
+      catch {
+        catch {$_.GetType().FullName}
+      }
+    }
+    else {    
+      $api_key =  if (Test-Path api_key) { gc api_key }
+                  elseif (Test-Path ..\api_key) { gc ..\api_key }
+                  elseif ($Env:api_key) { $Env:api_key }
+
+      if ($api_key) {
+          cpush $package.Name --api-key $api_key --source https://push.chocolatey.org 
+      } else {
+          cpush $package.Name --source https://push.chocolatey.org 
+      }
     }
 }


### PR DESCRIPTION
There are some workflow/usage patterns for Chocolatey simple server
that involve copying nupkg files directly to the
%installdir%\tools\chocolatey.server\App_Data\packages

this modification allows an environment variable override to
allow a simply move of the nupkg to the simpleserverPath

By moving, instead of copying, will rid the binary from the
git repository, eliminating untracked files.