### PR TITLE
Fix NuspecVersion returned by Update-Package for updated streams

### DIFF
--- a/AU/Public/Update-Package.ps1
+++ b/AU/Public/Update-Package.ps1
@@ -452,11 +452,8 @@ function Update-Package {
             set_latest $stream $package.Streams.$_.NuspecVersion $_
             process_stream
 
-            if ($package.Streams.$_) {
-                $allStreams.$_ = $package.Streams.$_
-            } else {
-                $allStreams.$_ = @{ NuspecVersion = $package.NuspecVersion }
-            }
+            $allStreams.$_ = if ($package.Streams.$_) { $package.Streams.$_.Clone() } else { @{} }
+            $allStreams.$_.NuspecVersion = $package.NuspecVersion
             $allStreams.$_ += $package.GetStreamDetails()
         }
         $package.Updated = $false

--- a/tests/Update-Package.Streams.Tests.ps1
+++ b/tests/Update-Package.Streams.Tests.ps1
@@ -180,8 +180,11 @@ Describe 'Update-Package using streams' -Tag updatestreams {
                 $res = update
 
                 $res.Updated      | Should Be $true
+                $res.Streams.'1.2'.NuspecVersion | Should Be 1.2.3
                 $res.Streams.'1.2'.RemoteVersion | Should Be 1.2.4
+                $res.Streams.'1.3'.NuspecVersion | Should Be 1.3.1
                 $res.Streams.'1.3'.RemoteVersion | Should Be 1.3.1
+                $res.Streams.'1.4'.NuspecVersion | Should Be 1.4-beta1
                 $res.Streams.'1.4'.RemoteVersion | Should Be 1.4.0
                 $res.Result[-1]   | Should Be 'Package updated'
                 (json_file).'1.2' | Should Be 1.2.4


### PR DESCRIPTION
@majkinetor, @AdmiringWorm, I just noticed that returned NuspecVersion was wrong when looking at Git Releases created on streamed packages: it contained the new version instead of the old one (e.g. https://github.com/chocolatey/chocolatey-coreteampackages/releases/tag/python2-2.6.6).