### PR TITLE
#126 Fix issue when using AU with PowerShell 5.0

### DIFF
--- a/AU/Plugins/History.ps1
+++ b/AU/Plugins/History.ps1
@@ -25,7 +25,7 @@ param(
 
 Write-Host "Saving history to $Path"
 
-$res=[ordered]@{}
+$res=[System.Collections.Specialized.OrderedDictionary]@{}
 $log = git --no-pager log -q --grep '^AU: ' --date iso | Out-String
 $all_commits = $log | sls 'commit(.|\n)+?(?=\ncommit )' -AllMatches
 foreach ($commit in $all_commits.Matches.Value) {
@@ -50,7 +50,7 @@ foreach ($commit in $all_commits.Matches.Value) {
     $res.$date += $packages_md
 }
 
-$res = $res.Keys | select -First $Lines | % { $r=[ordered]@{} } { $r[$_] = $res[$_] } {$r}
+$res = $res.Keys | select -First $Lines | % { $r=[System.Collections.Specialized.OrderedDictionary]@{} } { $r[$_] = $res[$_] } {$r}
 
 $history = @"
 # Update History

--- a/AU/Private/AUPackage.ps1
+++ b/AU/Private/AUPackage.ps1
@@ -53,7 +53,7 @@ class AUPackage {
 
     static [System.Collections.Specialized.OrderedDictionary] LoadStreams( $streamsPath ) {
         if (!(Test-Path $streamsPath)) { return $null }
-        $res = [ordered] @{}
+        $res = [System.Collections.Specialized.OrderedDictionary] @{}
         $versions = Get-Content $streamsPath | ConvertFrom-Json
         $versions.psobject.Properties | % {
             $stream = $_.Name
@@ -65,10 +65,10 @@ class AUPackage {
     UpdateStream( $stream, $version ){
         $s = $stream.ToString()
         $v = $version.ToString()
-        if (!$this.Streams) { $this.Streams = [ordered] @{} }
+        if (!$this.Streams) { $this.Streams = [System.Collections.Specialized.OrderedDictionary] @{} }
         if (!$this.Streams.Contains($s)) { $this.Streams.$s = @{} }
         if ($this.Streams.$s -ne 'ignore') { $this.Streams.$s.NuspecVersion = $v }
-        $versions = [ordered] @{}
+        $versions = [System.Collections.Specialized.OrderedDictionary] @{}
         $this.Streams.Keys | % {
             $versions.Add($_, $this.Streams.$_.NuspecVersion)
         }
@@ -98,7 +98,7 @@ class AUPackage {
             $this.$_ = $obj.$_
         }
         if ($obj.Streams) {
-            $this.Streams = [ordered] @{}
+            $this.Streams = [System.Collections.Specialized.OrderedDictionary] @{}
             $obj.Streams.psobject.Properties | % {
                 $this.Streams.Add($_.Name, $_.Value)
             }

--- a/AU/Public/Update-Package.ps1
+++ b/AU/Public/Update-Package.ps1
@@ -433,7 +433,7 @@ function Update-Package {
         $res.Keys | ? { $_ -ne 'Streams' } | % { $global:au_Latest.Remove($_) }
         $global:au_Latest += $res
 
-        $allStreams = [ordered] @{}
+        $allStreams = [System.Collections.Specialized.OrderedDictionary] @{}
         $streams | % {
             $stream = $res.Streams[$_]
 


### PR DESCRIPTION
Replace `[ordered]` by `[System.Collections.Specialized.OrderedDictionary]` to make AU work even on PowerShell 5.0. See https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_hash_tables...