### PR TITLE
Allow setting a custom mail from address

### DIFF
--- a/AU/Plugins/Mail.ps1
+++ b/AU/Plugins/Mail.ps1
@@ -4,6 +4,7 @@
 param(
     $Info,
     [string]   $To,
+    [Parameter(Mandatory=$false)][string] $From,
     [string]   $Server,
     [string]   $UserName,
     [string]   $Password,
@@ -23,7 +24,10 @@ if (($Info.error_count.total -eq 0) -and !$SendAlways) {
 $errors_word = if ($Info.error_count.total -eq 1) {'error'} else {'errors' }
 
 # Create mail message
-$from = "Update-AUPackages@{0}.{1}" -f $Env:UserName, $Env:ComputerName
+
+if ($null -eq $From) {
+  $From = "Update-AUPackages@{0}.{1}" -f $Env:UserName, $Env:ComputerName
+}
 
 $msg = New-Object System.Net.Mail.MailMessage $from, $To
 $msg.IsBodyHTML = $true


### PR DESCRIPTION
Some mail servers (e.g. Outlook.com) deny outgoing messages whose 'From'
mail address does not match the actual user account mail address.

This needs to be documented in AU-templates as well.