### PR TITLE
Add support for headers in Get-RemoteChecksum

### DIFF
--- a/AU/Public/Get-RemoteChecksum.ps1
+++ b/AU/Public/Get-RemoteChecksum.ps1
@@ -6,9 +6,9 @@
     Download file from internet and calculate its checksum
 
 #>
-function Get-RemoteChecksum( [string] $Url, $Algorithm='sha256' ) {
+function Get-RemoteChecksum( [string] $Url, $Algorithm='sha256', $Headers ) {
     $fn = [System.IO.Path]::GetTempFileName()
-    Invoke-WebRequest $Url -OutFile $fn -UseBasicParsing
+    Invoke-WebRequest $Url -OutFile $fn -UseBasicParsing -Headers $Headers
     $res = Get-FileHash $fn -Algorithm $Algorithm | % Hash
     rm $fn -ea ignore
     return $res.ToLower()


### PR DESCRIPTION
I think this may be useful for the same reasons as having it in `au_GetLatest`.

This `-Headers` parameter seems to be less restrictive and you only (theoritically) can't specify `User-Agent` and cookie headers. When I checked it though, I could specify `User-Agent` without any problems (not sure how to specify cookie headers), so I'm not sure, if it even restricts those headers.

I simply added new `$Headers` parameter to `Get-RemoteChecksum`, but I can change it to `$Options` and specify headers under it, if needed.