### PR TITLE
Fix updated stream version

### DIFF
--- a/AU/Plugins/Report/text.ps1
+++ b/AU/Plugins/Report/text.ps1
@@ -3,7 +3,7 @@ $Title       = if ($Params.Title) { $Params.Title } else {  'Update-AUPackages' 
 
 #==============================================================================
 
-function title($txt) { "r`n{0}`r`n{1}`r`n" -f $txt,('-'*$txt.Length) }
+function title($txt) { "`r`n{0}`r`n{1}`r`n" -f $txt,('-'*$txt.Length) }
 function indent($txt, $level=4) { $txt -split "`n" | % { ' '*$level + $_ } }
 
 $now         = $Info.startTime.ToUniversalTime().ToString('yyyy-MM-dd HH:mm')
@@ -31,7 +31,7 @@ if ($Info.pushed) {
     $Info.result.pushed | select 'Name', 'Updated', 'Pushed', 'RemoteVersion', 'NuspecVersion' | ft | Out-String | set r
     indent $r 2
 
-    $ok | % { $_.Name; indent $_.Result; "" }
+    $Info.result.pushed | % { $_.Name; indent $_.Result; "" }
 }
 
 if ($Info.error_count.total) {
@@ -39,7 +39,7 @@ if ($Info.error_count.total) {
     $Info.result.errors | select 'Name', 'NuspecVersion', 'Error' | ft | Out-String | set r
     indent $r 2
 
-    $Info.result.errors | % { $_.Name; ident $_.Error; "" }
+    $Info.result.errors | % { $_.Name; indent $_.Error; "" }
 }
 
 

--- a/AU/Public/Update-Package.ps1
+++ b/AU/Public/Update-Package.ps1
@@ -459,7 +459,11 @@ function Update-Package {
         }
         $package.Updated = $false
         $package.Streams = $allStreams
-        $package.Streams.Values | ? { $_.Updated } | % { $package.Updated = $true }
+        $package.Streams.Values | ? { $_.Updated } | % {
+            $package.NuspecVersion = $_.NuspecVersion
+            $package.RemoteVersion = $_.RemoteVersion
+            $package.Updated = $true
+        }
     } else {
         '' | result
         set_latest $res $package.NuspecVersion

--- a/tests/Update-AUPackages.Streams.Tests.ps1
+++ b/tests/Update-AUPackages.Streams.Tests.ps1
@@ -32,6 +32,104 @@ Describe 'Update-AUPackages using streams' -Tag updateallstreams {
     }
 
     Context 'Plugins' {
+        It 'should execute text Report plugin' {
+            gc $global:au_Root\test_package_with_streams_1\update.ps1 | set content
+            $content -replace '@\{.+1\.3.+\}', "@{ Version = '1.3.2' }" | set content
+            $content -replace '@\{.+1\.2.+\}', "@{ Version = '1.2.4' }" | set content
+            $content | sc $global:au_Root\test_package_with_streams_1\update.ps1
+
+            $Options.Report = @{
+                Type = 'text'
+                Path = "$global:au_Root\report.txt"
+            }
+
+            $res = updateall -NoPlugins:$false -Options $Options  6> $null
+
+            $pattern  = "\bFinished $pkg_no packages\b[\S\s]*"
+            $pattern += '\b1 updated\b[\S\s]*'
+            $pattern += '\b0 errors\b[\S\s]*'
+            $pattern += '\btest_package_with_streams_1 +True +1\.3\.2 +1\.3\.1\b[\S\s]*'
+            $pattern += "\btest_package_with_streams_2 +False +1\.4-beta1 +1\.4-beta1\b[\S\s]*"
+            $pattern += '\btest_package_with_streams_1\b[\S\s]*'
+            $pattern += '\bStream: 1\.2\b[\S\s]*'
+            $pattern += '\bnuspec version: 1\.2\.3\b[\S\s]*'
+            $pattern += '\bremote version: 1\.2\.4\b[\S\s]*'
+            $pattern += '\bNew version is available\b[\S\s]*'
+            $pattern += '\bStream: 1\.3\b[\S\s]*'
+            $pattern += '\bnuspec version: 1\.3\.1\b[\S\s]*'
+            $pattern += '\bremote version: 1\.3\.2\b[\S\s]*'
+            $pattern += '\bNew version is available\b[\S\s]*'
+            $pattern += '\bStream: 1\.4\b[\S\s]*'
+            $pattern += '\bnuspec version: 1\.4-beta1\b[\S\s]*'
+            $pattern += '\bremote version: 1\.4-beta1\b[\S\s]*'
+            $pattern += '\bNo new version found\b[\S\s]*'
+            $pattern += '\bPackage updated\b[\S\s]*'
+            $pattern += '\btest_package_with_streams_2\b[\S\s]*'
+            $pattern += '\bStream: 1\.2\b[\S\s]*'
+            $pattern += '\bnuspec version: 1\.2\.3\b[\S\s]*'
+            $pattern += '\bremote version: 1\.2\.3\b[\S\s]*'
+            $pattern += '\bNo new version found\b[\S\s]*'
+            $pattern += '\bStream: 1\.3\b[\S\s]*'
+            $pattern += '\bnuspec version: 1\.3\.1\b[\S\s]*'
+            $pattern += '\bremote version: 1\.3\.1\b[\S\s]*'
+            $pattern += '\bNo new version found\b[\S\s]*'
+            $pattern += '\bStream: 1\.4\b[\S\s]*'
+            $pattern += '\bnuspec version: 1\.4-beta1\b[\S\s]*'
+            $pattern += '\bremote version: 1\.4-beta1\b[\S\s]*'
+            $pattern += '\bNo new version found\b[\S\s]*'
+            $Options.Report.Path | Should Exist
+            $Options.Report.Path | Should FileContentMatchMultiline $pattern
+        }
+
+        It 'should execute markdown Report plugin' {
+            gc $global:au_Root\test_package_with_streams_1\update.ps1 | set content
+            $content -replace '@\{.+1\.3.+\}', "@{ Version = '1.3.2' }" | set content
+            $content -replace '@\{.+1\.2.+\}', "@{ Version = '1.2.4' }" | set content
+            $content | sc $global:au_Root\test_package_with_streams_1\update.ps1
+
+            $Options.Report = @{
+                Type = 'markdown'
+                Path = "$global:au_Root\report.md"
+                Params = @{ Github_UserRepo = 'majkinetor/chocolatey' }
+            }
+
+            $res = updateall -NoPlugins:$false -Options $Options  6> $null
+
+            $pattern  = "\bFinished $pkg_no packages\b[\S\s]*"
+            $pattern += '\b1 updated\b[\S\s]*'
+            $pattern += '\b0 errors\b[\S\s]*'
+            $pattern += '\btest_package_with_streams_1\b.*\bTrue\b.*\bFalse\b.*\b1\.3\.2\b.*\b1\.3\.1\b[\S\s]*'
+            $pattern += "\btest_package_with_streams_2\b.*\bFalse\b.*\bFalse\b.*\b1\.4-beta1\b.*\b1\.4-beta1\b[\S\s]*"
+            $pattern += '\btest_package_with_streams_1\b[\S\s]*'
+            $pattern += '\bStream: 1\.2\b[\S\s]*'
+            $pattern += '\bnuspec version: 1\.2\.3\b[\S\s]*'
+            $pattern += '\bremote version: 1\.2\.4\b[\S\s]*'
+            $pattern += '\bNew version is available\b[\S\s]*'
+            $pattern += '\bStream: 1\.3\b[\S\s]*'
+            $pattern += '\bnuspec version: 1\.3\.1\b[\S\s]*'
+            $pattern += '\bremote version: 1\.3\.2\b[\S\s]*'
+            $pattern += '\bNew version is available\b[\S\s]*'
+            $pattern += '\bStream: 1\.4\b[\S\s]*'
+            $pattern += '\bnuspec version: 1\.4-beta1\b[\S\s]*'
+            $pattern += '\bremote version: 1\.4-beta1\b[\S\s]*'
+            $pattern += '\bNo new version found\b[\S\s]*'
+            $pattern += '\bPackage updated\b[\S\s]*'
+            $pattern += '\btest_package_with_streams_2\b[\S\s]*'
+            $pattern += '\bStream: 1\.2\b[\S\s]*'
+            $pattern += '\bnuspec version: 1\.2\.3\b[\S\s]*'
+            $pattern += '\bremote version: 1\.2\.3\b[\S\s]*'
+            $pattern += '\bNo new version found\b[\S\s]*'
+            $pattern += '\bStream: 1\.3\b[\S\s]*'
+            $pattern += '\bnuspec version: 1\.3\.1\b[\S\s]*'
+            $pattern += '\bremote version: 1\.3\.1\b[\S\s]*'
+            $pattern += '\bNo new version found\b[\S\s]*'
+            $pattern += '\bStream: 1\.4\b[\S\s]*'
+            $pattern += '\bnuspec version: 1\.4-beta1\b[\S\s]*'
+            $pattern += '\bremote version: 1\.4-beta1\b[\S\s]*'
+            $pattern += '\bNo new version found\b[\S\s]*'
+            $Options.Report.Path | Should Exist
+            $Options.Report.Path | Should FileContentMatchMultiline $pattern
+        }
 
         It 'should execute GitReleases plugin when there are updates' {
             gc $global:au_Root\test_package_with_streams_1\update.ps1 | set content

--- a/tests/Update-Package.Streams.Tests.ps1
+++ b/tests/Update-Package.Streams.Tests.ps1
@@ -164,9 +164,14 @@ Describe 'Update-Package using streams' -Tag updatestreams {
                 $res = update
 
                 $res.Updated      | Should Be $true
-                $res.Streams.'1.2'.RemoteVersion       | Should Be 1.2.4
-                $res.Streams.'1.3'.RemoteVersion       | Should Be 1.3.1
-                $res.Streams.'1.4'.RemoteVersion       | Should Be 1.4-beta1
+                $res.NuspecVersion               | Should Be 1.2.3
+                $res.RemoteVersion               | Should Be 1.2.4
+                $res.Streams.'1.2'.NuspecVersion | Should Be 1.2.3
+                $res.Streams.'1.2'.RemoteVersion | Should Be 1.2.4
+                $res.Streams.'1.3'.NuspecVersion | Should Be 1.3.1
+                $res.Streams.'1.3'.RemoteVersion | Should Be 1.3.1
+                $res.Streams.'1.4'.NuspecVersion | Should Be 1.4-beta1
+                $res.Streams.'1.4'.RemoteVersion | Should Be 1.4-beta1
                 $res.Result[-1]   | Should Be 'Package updated'
                 (nuspec_file).package.metadata.version | Should Be 1.2.4
                 (json_file).'1.2' | Should Be 1.2.4
@@ -175,21 +180,23 @@ Describe 'Update-Package using streams' -Tag updatestreams {
             }
 
             It 'updates package when multiple remote versions are higher' {
-                get_latest -Version 1.4.0
+                get_latest -Version 1.3.2
 
                 $res = update
 
                 $res.Updated      | Should Be $true
+                $res.NuspecVersion               | Should Be 1.3.1
+                $res.RemoteVersion               | Should Be 1.3.2
                 $res.Streams.'1.2'.NuspecVersion | Should Be 1.2.3
                 $res.Streams.'1.2'.RemoteVersion | Should Be 1.2.4
                 $res.Streams.'1.3'.NuspecVersion | Should Be 1.3.1
-                $res.Streams.'1.3'.RemoteVersion | Should Be 1.3.1
+                $res.Streams.'1.3'.RemoteVersion | Should Be 1.3.2
                 $res.Streams.'1.4'.NuspecVersion | Should Be 1.4-beta1
-                $res.Streams.'1.4'.RemoteVersion | Should Be 1.4.0
+                $res.Streams.'1.4'.RemoteVersion | Should Be 1.4-beta1
                 $res.Result[-1]   | Should Be 'Package updated'
                 (json_file).'1.2' | Should Be 1.2.4
-                (json_file).'1.3' | Should Be 1.3.1
-                (json_file).'1.4' | Should Be 1.4.0
+                (json_file).'1.3' | Should Be 1.3.2
+                (json_file).'1.4' | Should Be 1.4-beta1
             }
 
             It "does not update the package when remote version is not higher" {


### PR DESCRIPTION
Fixes #160.

When dealing with updated streams, `Update-Package.ps1` now returns an object that contains the information of the latest updated stream instead of containing the latest stream.

I also added some tests on the report plugin to make sure it's all good (I fixed at the same time some minor issues with text reports).