### PR TITLE
Fixes compatibility issue with the latest version of Pester

### DIFF
--- a/tests/Update-Package.Tests.ps1
+++ b/tests/Update-Package.Tests.ps1
@@ -213,24 +213,24 @@ Describe 'Update-Package' -Tag update {
 
             It 'sets Force parameter from global variable au_Force if it is not bound' {
                 $global:au_Force = $true
-                $msg = "Parameter Force set from global variable au_Force: $au_Force"
+                $filter_msg = "Parameter Force set from global variable au_Force: $au_Force"
                 update -Verbose
-                Assert-MockCalled Write-Verbose -ParameterFilter { $Message -eq $msg }
+                Assert-MockCalled Write-Verbose -ParameterFilter { $Message -eq $filter_msg }
 
             }
 
             It "doesn't set Force parameter from global variable au_Force if it is bound" {
                 $global:au_Force = $true
-                $msg = "Parameter Force set from global variable au_Force: $au_Force"
+                $filter_msg = "Parameter Force set from global variable au_Force: $au_Force"
                 update -Verbose -Force:$false
-                Assert-MockCalled Write-Verbose -ParameterFilter { $Message -ne $msg }
+                Assert-MockCalled Write-Verbose -ParameterFilter { $Message -ne $filter_msg }
             }
 
             It 'sets Timeout parameter from global variable au_Timeout if it is not bound' {
                 $global:au_Timeout = 50
-                $msg = "Parameter Timeout set from global variable au_Timeout: $au_Timeout"
+                $filter_msg = "Parameter Timeout set from global variable au_Timeout: $au_Timeout"
                 update -Verbose
-                Assert-MockCalled Write-Verbose -ParameterFilter { $Message -eq $msg }
+                Assert-MockCalled Write-Verbose -ParameterFilter { $Message -eq $filter_msg }
             }
 
         }


### PR DESCRIPTION
Hi @majkinetor,

Starting in "4.7.0-beta1" version, Pester started to support parameter aliases in the script blocks.

This leads to transformations of the following type:
`$Message -ne $msg` to `$Message -ne $Message`

Making some tests fail or lose effect.
This PR fixes three cases found in the test suite.
Tested with Pester latest stable version: 4.7.3 