### PR TITLE
Add pester tests when 'ignore' is returned

### DIFF
--- a/tests/Update-AUPackages.Streams.Tests.ps1
+++ b/tests/Update-AUPackages.Streams.Tests.ps1
@@ -32,6 +32,17 @@ Describe 'Update-AUPackages using streams' -Tag updateallstreams {
     }
 
     Context 'Plugins' {
+        It 'should ignore the package that returns "ignore"' {
+            gc $global:au_Root\test_package_with_streams_1\update.ps1 | set content
+            $content -replace 'update', "Write-Host 'test ignore'; 'ignore'" | set content
+            $content | sc $global:au_Root\test_package_with_streams_1\update.ps1
+
+            $res = updateall -Options $Options -NoPlugins:$false 6>$null
+
+            $res[0].Ignored | Should Be $true
+            $res[0].IgnoreMessage | Should Be 'test ignore'
+        }
+
         It 'should execute text Report plugin' {
             gc $global:au_Root\test_package_with_streams_1\update.ps1 | set content
             $content -replace '@\{.+1\.3.+\}', "@{ Version = '1.3.2' }" | set content

--- a/tests/Update-Package.Streams.Tests.ps1
+++ b/tests/Update-Package.Streams.Tests.ps1
@@ -312,6 +312,25 @@ Describe 'Update-Package using streams' -Tag updatestreams {
                 { update } | Should Throw "returned nothing"
             }
 
+            It 'supports returning "ignore"' {
+                function global:au_GetLatest { 'ignore' }
+                $res = update
+                $res | Should BeExactly 'ignore'
+            }
+
+            It 'supports returning "ignore" on specific streams' {
+                function global:au_GetLatest { @{ Streams = [ordered] @{
+                    '1.4' = @{ Version = '1.4.0' }
+                    '1.3' = 'ignore'
+                    '1.2' = @{ Version = '1.2.4' }
+                } } }
+                $res = update
+                $res.Streams.Count | Should Be 2
+                $res.Streams.Keys | Should Contain '1.4'
+                $res.Streams.Keys | Should Not Contain '1.3'
+                $res.Streams.Keys | Should Contain '1.2'
+            }
+
             It "supports properties defined outside streams" {
                 get_latest -Version 1.4.0
                 function au_BeforeUpdate { $global:Latest.Fake | Should Be 1 }

--- a/tests/Update-Package.Tests.ps1
+++ b/tests/Update-Package.Tests.ps1
@@ -287,6 +287,12 @@ Describe 'Update-Package' -Tag update {
                 update
             }
 
+            It 'supports returning "ignore"' {
+                function global:au_GetLatest { 'ignore' }
+                $res = update
+                $res | Should BeExactly 'ignore'
+            }
+
             It 'supports returning custom values' {
                 function global:au_GetLatest { @{ Version = '1.2'; NewValue = 1 } }
                 update


### PR DESCRIPTION
Here are some new pester tests regarding the ability to return "ignore" in `au_GetLatest` (for streams or not) as well as in `update.ps1` scripts (for streams).

@majkinetor, I let you review and merge if this is ok with what you expected in #185.