### PR TITLE
Improve output when ignoring streams

### DIFF
--- a/AU/Public/Update-Package.ps1
+++ b/AU/Public/Update-Package.ps1
@@ -442,7 +442,10 @@ function Update-Package {
             "*** Stream: $_ ***" | result
 
             if ($stream -eq $null) { throw "au_GetLatest's $_ stream returned nothing" }
-            if ($stream -eq 'ignore') { return }
+            if ($stream -eq 'ignore') {
+                $stream | result
+                return
+            }
             if ($stream -isnot [HashTable]) { throw "au_GetLatest's $_ stream doesn't return a HashTable result but $($stream.GetType())" }
 
             if ($package.Streams.$_.NuspecVersion -eq 'ignore') {
@@ -470,7 +473,10 @@ function Update-Package {
         process_stream
     }
 
-    if ($package.Updated) { 'Package updated' | result }
+    if ($package.Updated) {
+        '' | result
+        'Package updated' | result
+    }
 
     return $package
 }


### PR DESCRIPTION
Improve output when ignoring streams (fix #189):

- I have added a message to confirm the ignore state of a stream (as it is the case for packages without streams).
- I have added an empty line before the `Package updated` message.