### PR TITLE
Improved support for non-official repositories

### DIFF
--- a/AU/Public/Push-Package.ps1
+++ b/AU/Public/Push-Package.ps1
@@ -14,15 +14,20 @@ function Push-Package() {
         [switch] $All
     )
     $api_key =  if (Test-Path api_key) { gc api_key }
-                elseif (Test-Path ..\api_key) { gc ..\api_key }
-                elseif ($Env:api_key) { $Env:api_key }
+    elseif (Test-Path ..\api_key) { gc ..\api_key }
+    elseif ($Env:api_key) { $Env:api_key }
 
     $push_url =  if ($Env:au_PushUrl) { $Env:au_PushUrl }
                  else { 'https://push.chocolatey.org' }
 
-    $push_force =  if ($Env:au_PushForce) { $true } else { $false }
+    $push_force =  if ($Env:au_PushForce -eq 'true') { $true } else { $false }
 
-    $SecureSource = cpush --source $push_url
+    $SecureSource =  if ($api_key) {
+        $packages | % { cpush --api-key $api_key --source $push_url }
+    } else {
+        $packages | % { cpush --source $push_url }
+    }
+    
     if ( $push_force ) {
         if ( $SecureSource | select-string "The specified source `'$($push_url)`' is not secure." ) {
             Write-Output "Source is insecure. Will use -Force"

--- a/AU/Public/Update-Package.ps1
+++ b/AU/Public/Update-Package.ps1
@@ -223,7 +223,7 @@ function Update-Package {
         $script:is_forced = $false
         if ([AUVersion] $Latest.Version -gt [AUVersion] $Latest.NuspecVersion) {
             if (!($NoCheckChocoVersion -or $Force)) {
-                if ( !$au_GalleryUrl ) { $au_GalleryUrl = 'https://chocolatey.org' } 
+                if ( !$Env:au_GalleryUrl ) { $Env:au_GalleryUrl = 'https://chocolatey.org' } 
                 $choco_url = "$au_GalleryUrl/packages/{0}/{1}" -f $global:Latest.PackageName, $package.RemoteVersion
                 try {
                     request $choco_url $Timeout | out-null


### PR DESCRIPTION
## Push-Package
#### Lines 23-36
The changes made rely on a new environment variable, $Env:au_PushForce. When set, a push with no package will be attempted against $push_url in order to determine if the source is insecure (this is to avoid the risk of needlessly using force against a secure source, and forcing a different operation). If it is insecure, the string variable $ForceParam will be define as '--Force' and cleared if not.

#### Lines 41 & 43
Regardless of the above evaluation, the contents of $ForceParam will be appended to the push command. If the conditions to set --Force were not met above, nothing will be added due to the empty value.

## Update-Package
I was unable to get the variable $au_GalleryUrl to make a difference with various other changes to the code, so I can only conclude that a mistake was made here and it should have been an environment variable to begin with.