### PR TITLE
GitLab API Key support

### DIFF
--- a/AU/Plugins/GitLab.ps1
+++ b/AU/Plugins/GitLab.ps1
@@ -1,0 +1,108 @@
+# Author: Josh Ameli <contact@jekotia.net>
+# Based off of the Git plugin by Miodrag Milic <miodrag.milic@gmail.com>
+# Last Change: 20-Aug-2019.
+
+# https://www.appveyor.com/docs/how-to/git-push/
+
+param(
+    $Info,
+
+    # GitLab username
+    [string] $User,
+
+    # GitLab API key.
+    [string] $API_Key,
+
+    # Repository HTTP(S) URL
+    [string]$PushURL,
+
+    # Force git commit when package is updated but not pushed.
+    [switch] $Force,
+
+    # Commit strategy: 
+    #  single    - 1 commit with all packages
+    #  atomic    - 1 commit per package    
+    #  atomictag - 1 commit and tag per package
+    [ValidateSet('single', 'atomic', 'atomictag')]
+    [string]$commitStrategy = 'single',
+
+    # Branch name
+    [string]$Branch = 'master'
+)
+
+[array]$packages = if ($Force) { $Info.result.updated } else { $Info.result.pushed }
+if ($packages.Length -eq 0) { Write-Host "No package updated, skipping"; return }
+
+$root = Split-Path $packages[0].Path
+
+pushd $root
+$origin  = git config --get remote.origin.url
+$origin -match '(?<=:/+)[^/]+' | Out-Null
+$machine = $Matches[0]
+
+### Construct RepoURL to be set as new origin
+$RepoURL = (
+    $PushURL.split('://')[0] `
+    + "://" `
+    + $User `
+    + ":" `
+    + $API_Key `
+    + "@" `
+    + $PushURL.TrimStart(
+        $(
+            $PushURL.split('://')[0] `
+            + "://"
+        )
+    )
+)
+
+### Set new push URL
+git remote set-url origin $RepoURL
+
+### Ensure local is up-to-date to avoid conflicts
+Write-Host "Executing git pull"
+git checkout -q $Branch
+git pull -q origin $Branch
+
+### Commit
+if  ($commitStrategy -like 'atomic*') {
+    $packages | % {
+        Write-Host "Adding update package to git repository: $($_.Name)"
+        git add -u $_.Path
+        git status
+
+        Write-Host "Commiting $($_.Name)"
+        $message = "AU: $($_.Name) upgraded from $($_.NuspecVersion) to $($_.RemoteVersion)"
+        $gist_url = $Info.plugin_results.Gist -split '\n' | select -Last 1
+        $snippet_url = $Info.plugin_results.Snippet -split '\n' | select -Last 1
+        git commit -m "$message`n[skip ci] $gist_url $snippet_url" --allow-empty
+
+        if ($commitStrategy -eq 'atomictag') {
+          $tagcmd = "git tag -a $($_.Name)-$($_.RemoteVersion) -m '$($_.Name)-$($_.RemoteVersion)'"
+          Invoke-Expression $tagcmd
+        }
+    }
+}
+else {
+    Write-Host "Adding updated packages to git repository: $( $packages | % Name)"
+    $packages | % { git add -u $_.Path }
+    git status
+
+    Write-Host "Commiting"
+    $message = "AU: $($packages.Length) updated - $($packages | % Name)"
+    $gist_url = $Info.plugin_results.Gist -split '\n' | select -Last 1
+    $snippet_url = $Info.plugin_results.Snippet -split '\n' | select -Last 1
+    git commit -m "$message`n[skip ci] $gist_url $snippet_url" --allow-empty
+
+}
+
+### Push
+Write-Host "Pushing changes"
+git push -q 
+if ($commitStrategy -eq 'atomictag') {
+    write-host 'Atomic Tag Push'
+    git push -q --tags
+}
+popd
+
+git remote set-url origin $origin

--- a/Plugins.md
+++ b/Plugins.md
@@ -27,6 +27,15 @@ To set up plugin to create gist under your user name you need to give it your gi
 * To use it locally, just ensure `git push` doesn't require credentials and dont set any environment variables. 
 * To use on build server such as [[AppVeyor]], specify `$Env:username` and `$Env:password`. If you host git repository on Github its preferable to use personal access token. You can use the same token as with gist as long as _**public repo**_ scope is activated.
 
+## [GitLab](https://github.com/majkinetor/au/blob/master/AU/Plugins/GitLab.ps1)
+
+**Persist modified files**.
+
+* Same functionality as Git plugin, but tailored to HTTP(S) API-key pushes against a GitLab server.
+* To use on build server such as [[AppVeyor]], specify `$Env:gitlab_user`, `$Env:gitlab_apikey`, and `$Env:gitlab_pushurl`.
+* `pushurl` must be a full HTTP(S) URL to the repo; the same one you would use to clone it. Internal plugin logic will use this to reconstruct a compatible URL.
+
+
 ## [GitReleases](https://github.com/majkinetor/au/blob/master/AU/Plugins/GitReleases.ps1)
 
 **Creates Github release for updated packages**.

--- a/vars_default.ps1
+++ b/vars_default.ps1
@@ -4,3 +4,8 @@ $Env:Github_UserRepo   = ''   # Publish to Github; commit git changes
 $Env:Github_ApiKey     = ''   # Publish to Github token
 $Env:NuGet_ApiKey      = ''   # Publish to PSGallery token
 $Env:Chocolatey_ApiKey = ''   # Publish to Chocolatey token
+
+$Env:gitlab_user            = ''   # GitLab username to use for the push
+$Env:gitlab_api_key         = ''   # GitLab API key associated with gitlab_user
+$Env:gitlab_push_url        = ''   # GitLab URL to push to. Must be HTTP or HTTPS. e.g. https://jekotia:MyPassword@git.example.org/jekotia/au.git
+$Env:gitlab_commit_strategy = ''   # Same values as the Git plugin; single, atomic, or atomictag


### PR DESCRIPTION
Tested against internal GitLab CE instance.
Successfully tested both locally and from AppVeyor.

This plugin is based off of the existing Git.ps1 plugin and offers tailored support for pushing to GitLab via HTTP(S) using API keys.