### PR TITLE
Better logging for invalid URLs

### DIFF
--- a/AU/Public/Update-Package.ps1
+++ b/AU/Public/Update-Package.ps1
@@ -107,7 +107,7 @@ function Update-Package {
         "URL check" | result
         $Latest.Keys | ? {$_ -like 'url*' } | % {
             $url = $Latest[ $_ ]
-            if ($res = check_url $url -Options $Latest.Options) { throw "${res}:$url" } else { "  $url" | result }
+            if ($res = check_url $url -Options $Latest.Options) { throw "${res}: '$url' ($_)" } else { "  $url" | result }
         }
     }
 


### PR DESCRIPTION
As described in #204 we need to know what parameter was responsible for the invalid URL message.