### PR TITLE
fix sourcing

### DIFF
--- a/AU/AU.psm1
+++ b/AU/AU.psm1
@@ -2,5 +2,5 @@
 
 $paths = "Private", "Public"
 foreach ($path in $paths) {
-    ls $PSScriptRoot\$path\*.ps1 | % { . $_ }
+    Get-ChildItem $PSScriptRoot\$path\*.ps1 | ForEach-Object { . $_.FullName }
 }


### PR DESCRIPTION
in newer version of Windows PowerShell the `. $_` does not actually source the files.

Chose to expand aliases as well.

Instead what happens is powershell will echo the `get-childitem` to terminal:
```powershell
> $PSVersionTable.PSVersion                                                                                             
Major  Minor  Build  Revision
-----  -----  -----  --------
5      1      19041  1

> Import-Module au

   Directory: C:\Users\joseph\Documents\PowerShell\Modules\AU\2019.5.22\Private

AUPackage.ps1    AUVersion.ps1    check_url.ps1    is_url.ps1       is_version.ps1   request.ps1

   Directory: C:\Users\joseph\Documents\PowerShell\Modules\AU\2019.5.22\Public

Get-AUPackages.ps1                      Get-RemoteChecksum.ps1                  Get-RemoteFiles.ps1
Get-Version.ps1                         Push-Package.ps1                        Set-DescriptionFromReadme.ps1
Test-Package.ps1                        Update-AUPackages.ps1                   Update-Package.ps1
```