### PR TITLE
Refresh options headers downloading multiple files

### DIFF
--- a/AU/Public/Get-RemoteFiles.ps1
+++ b/AU/Public/Get-RemoteFiles.ps1
@@ -61,14 +61,17 @@ function Get-RemoteFiles {
         rm -Force "$toolsPath\*.$ext" -ea ignore
     }
 
-    try {
-        $client = New-Object System.Net.WebClient
-        
+    function headers($client) {
         if ($Latest.Options.Headers) {
             $Latest.Options.Headers.GetEnumerator() | % { $client.Headers.Add($_.Key, $_.Value) | Out-Null }
         }
+    }
 
+    try {
+        $client = New-Object System.Net.WebClient
+        
         if ($Latest.Url32) {
+            headers($client)
             $base_name = name4url $Latest.Url32
             $file_name = "{0}{2}.{1}" -f $base_name, $ext, $(if ($NoSuffix) { '' } else {'_x32'})
             $file_path = "$toolsPath\$file_name"
@@ -81,6 +84,7 @@ function Get-RemoteFiles {
         }
 
         if ($Latest.Url64) {
+            headers($client)
             $base_name = name4url $Latest.Url64
             $file_name = "{0}{2}.{1}" -f $base_name, $ext, $(if ($NoSuffix) { '' } else {'_x64'})
             $file_path = "$toolsPath\$file_name"


### PR DESCRIPTION
Headers defined in options are injected into the WebClient instance used to
download files.  This is done to support downloading files where headers
are required eg. Referrer.  The headers can be defined and injected via
$Latest.Options.Headers.

The headers are cleared when a download is performed with DownloadFile
so where multiple files are downlaoded the headers are not available for
the second download.  This impacts when a package requries  both 32-bit
and 64-bit files to be downloaded during package construction.

To address this the headers should be injected prior to each download to
ensure that they are available.

Resolves #218