### PR TITLE
Support ChocolateyPackageFolder environment variable

### DIFF
--- a/AU/Public/Update-Package.ps1
+++ b/AU/Public/Update-Package.ps1
@@ -121,7 +121,8 @@ function Update-Package {
             if ($ChecksumFor -eq 'none') { "Automatic checksum calculation is disabled"; return }
             if ($ChecksumFor -eq 'all')  { $arch = '32','64' } else { $arch = $ChecksumFor }
 
-            $pkg_path = [System.IO.Path]::GetFullPath("$Env:TEMP\chocolatey\$($package.Name)\" + $global:Latest.Version) #https://github.com/majkinetor/au/issues/32
+            $Env:ChocolateyPackageFolder = [System.IO.Path]::GetFullPath("$Env:TEMP\chocolatey\$($package.Name)") #https://github.com/majkinetor/au/issues/32
+            $pkg_path = Join-Path $Env:ChocolateyPackageFolder $global:Latest.Version
             mkdir -Force $pkg_path | Out-Null
 
             $Env:ChocolateyPackageName         = "chocolatey\$($package.Name)"


### PR DESCRIPTION
I just noticed that `ChocolateyPackageFolder` environment variable is not set while upgrading a package. This can lead to errors if `chocolateyInstall.ps1` is using this variable and expect it to be set.

Here is an example: https://github.com/Thilas/chocolatey-packages/blob/master/vscodium.portable/tools/chocolateyInstall.ps1#L6