### PR TITLE
replaced the fixed target_commitish of "master"

### DIFF
--- a/AU/Plugins/GitReleases.ps1
+++ b/AU/Plugins/GitReleases.ps1
@@ -25,7 +25,10 @@ param(
     [string]$dateFormat = '{0:yyyy-MM-dd}',
 
     # Force creating a release when a package have been updated and not just been pushed.
-    [switch]$Force
+    [switch]$Force,
+
+    # The name of the branch, to create the release at
+    [string]$Branch = 'master'
 )
 
 function GetOrCreateRelease() {
@@ -48,7 +51,7 @@ function GetOrCreateRelease() {
 
     $json = @{
         "tag_name"         = $tagName
-        "target_commitish" = "master"
+        "target_commitish" = $Branch
         "name"             = $releaseName
         "body"             = $releaseDescription
         "draft"            = $false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
    - New plugin: Gitlab ([#195](https://github.com/majkinetor/au/pull/195))
    - Gist: option for secret gist and Enterprise API
 - Improved Powershell 7 compatibility ([#208](https://github.com/majkinetor/au/issues/208))
+- Added a `Branch` parameter to GitReleases ([#227](https://github.com/majkinetor/au/issues/227))
 
 ## 2019.5.22
 


### PR DESCRIPTION
with a parameter. The Parameter is called "Branch" because that's what
will most likely be used. It is however possible to insert a tag or
commit-sha.

Additionally, the default for `Branch` is `master`, so that the current behavior is unchanged.

fixes #227 