### PR TITLE
Selects first date occurance

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -27,7 +27,7 @@ param(
 $b = {
     if ($Clean) { git clean -Xfd -e vars.ps1; return }
     if ($ShortVersion) { $Version = [string] $Version = [Version](Get-Date).ToUniversalTime().ToString("yyyy.M.d") }
-    if ($LastCommitDate) { $Version = [string] $Version = [Version]$((git log -1 --date=short) | Where-Object { $_ -match "date"}).split(' ')[-1].replace("-",".") }
+    if ($LastCommitDate) { $Version = [string] $Version = [Version]$(((git log -1 --date=short) | Where-Object { $_ -match "date:"}) | Select-Object -First 1).split(' ')[-1].replace("-",".") }
 
     $module_path    = "$PSScriptRoot/AU"
     $module_name    = Split-Path -Leaf $module_path


### PR DESCRIPTION
Selects first output, the release is failling if the commit contains the date word, now by taking the first result, we won't risk it again