### PR TITLE
Don't set SSLv3 on PowerShell 6+

### DIFF
--- a/AU/Plugins/Gist.ps1
+++ b/AU/Plugins/Gist.ps1
@@ -46,7 +46,12 @@ Get-ChildItem $Path | ForEach-Object {
 # request
 
 #https://github.com/majkinetor/au/issues/142
-[System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor [System.Net.SecurityProtocolType]::Tls -bor [System.Net.SecurityProtocolType]::Ssl3
+if ($PSVersionTable.PSVersion.major -ge 6) {
+    $AvailableTls = [enum]::GetValues('Net.SecurityProtocolType') | Where-Object { $_ -ge 'Tls' } # PowerShell 6+ does not support SSL3, so use TLS minimum
+    $AvailableTls.ForEach({[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor $_})
+} else {
+    [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor [System.Net.SecurityProtocolType]::Tls -bor [System.Net.SecurityProtocolType]::Ssl3
+}
 
 $params = @{
     ContentType = 'application/json'

--- a/AU/Public/Update-Package.ps1
+++ b/AU/Public/Update-Package.ps1
@@ -382,10 +382,14 @@ function Update-Package {
 
     $global:Latest = @{PackageName = $package.Name}
 
-    # https://github.com/majkinetor/au/issues/206
+    if ($PSVersionTable.PSVersion.major -ge 6) {
+        $AvailableTls = [enum]::GetValues('Net.SecurityProtocolType') | Where-Object { $_ -ge 'Tls' } # PowerShell 6+ does not support SSL3, so use TLS minimum
+    } else {
+        # https://github.com/majkinetor/au/issues/206
+        $AvailableTls = [enum]::GetValues('Net.SecurityProtocolType') # This way we do not try to add something that is not supported on every version of Windows like Tls13
+        #$AvailableTls = [enum]::GetValues('Net.SecurityProtocolType') | Where-Object { $_ -ge 'Tls' } If we want to enforce a minimum version
+    }
 
-    $AvailableTls = [enum]::GetValues('Net.SecurityProtocolType') # This way we do not try to add something that is not supported on every version of Windows like Tls13
-    #$AvailableTls = [enum]::GetValues('Net.SecurityProtocolType') | Where-Object { $_ -ge 'Tls' } If we want to enforce a minimum version
     $AvailableTls.ForEach({[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor $_})
     
 


### PR DESCRIPTION
So it looks like SSLv3 is not supported on all platforms for PowerShell core, not only Linux.

This keeps the current behavior when run under WindowsPowerShell, but selects TLS minimum for PowerShell 6+.

Related:
#206 
#216 
#233 
#234 