### PR TITLE
Make directory separators platform agnostic

### DIFF
--- a/AU/AU.psm1
+++ b/AU/AU.psm1
@@ -2,5 +2,5 @@
 
 $paths = "Private", "Public"
 foreach ($path in $paths) {
-    Get-ChildItem $PSScriptRoot\$path\*.ps1 | ForEach-Object { . $_.FullName }
+    Get-ChildItem ([System.IO.Path]::Combine($PSScriptRoot, $path, '*.ps1')) | ForEach-Object { . $_.FullName }
 }

--- a/AU/Plugins/Report.ps1
+++ b/AU/Plugins/Report.ps1
@@ -24,7 +24,7 @@ param(
 
 Write-Host "Saving $Type report: $Path"
 
-$Type = "$PSScriptRoot\Report\$Type.ps1"
+$Type = ([System.IO.Path]::Combine($PSScriptRoot, 'Report', "$Type.ps1"))
 if (!(Test-Path $Type )) { throw "Report type not found: '$Type" }
 
 $result = & $Type

--- a/AU/Plugins/Report/markdown.ps1
+++ b/AU/Plugins/Report/markdown.ps1
@@ -1,4 +1,4 @@
-. $PSScriptRoot\markdown_funcs.ps1
+. (Join-Path $PSScriptRoot 'markdown_funcs.ps1')
 
 $Github_UserRepo = $Params.Github_UserRepo
 $UserMessage     = $Params.UserMessage

--- a/AU/Private/AUPackage.ps1
+++ b/AU/Private/AUPackage.ps1
@@ -20,13 +20,13 @@ class AUPackage {
         $this.Path = $Path
         $this.Name = Split-Path -Leaf $Path
 
-        $this.NuspecPath = '{0}\{1}.nuspec' -f $this.Path, $this.Name
+        $this.NuspecPath = '{0}{2}{1}.nuspec' -f $this.Path, $this.Name, [IO.Path]::DirectorySeparatorChar
         if (!(Get-Item $this.NuspecPath -ea ignore)) { throw 'No nuspec file found in the package directory' }
 
         $this.NuspecXml     = [AUPackage]::LoadNuspecFile( $this.NuspecPath )
         $this.NuspecVersion = $this.NuspecXml.package.metadata.version
 
-        $this.StreamsPath = '{0}\{1}.json' -f $this.Path, $this.Name
+        $this.StreamsPath = '{0}{2}{1}.json' -f $this.Path, $this.Name, [IO.Path]::DirectorySeparatorChar
         $this.Streams     = [AUPackage]::LoadStreams( $this.StreamsPath )
     }
 
@@ -76,20 +76,20 @@ class AUPackage {
     }
 
     Backup()  { 
-        $d = "$Env:TEMP\au\" + $this.Name
+        $d = ([System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), 'au', $this.Name))
 
-        Remove-Item $d\* -Recurse -ea 0
-        Copy-Item . $d\_backup -Recurse 
+        Remove-Item (Join-Path $d '*') -Recurse -ea 0
+        Copy-Item . (Join-Path $d '_backup') -Recurse 
     }
 
     [string] SaveAndRestore() { 
-        $d = "$Env:TEMP\au\" + $this.Name
+        $d = ([System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), 'au', $this.Name))
 
-        Copy-Item . $d\_output -Recurse 
-        Remove-Item .\* -Recurse
-        Copy-Item $d\_backup\* . -Recurse 
+        Copy-Item . (Join-Path $d '_output') -Recurse 
+        Remove-Item (Join-Path '.' '*') -Recurse
+        Copy-Item ([System.IO.Path]::Combine($d, '_backup', '*')) . -Recurse 
         
-        return "$d\_output"
+        return (Join-Path $d '_output')
     }
 
     AUPackage( [hashtable] $obj ) {

--- a/AU/Public/Get-AUPackages.ps1
+++ b/AU/Public/Get-AUPackages.ps1
@@ -28,7 +28,7 @@ function Get-AUPackages( [string[]] $Name ) {
     $root = $global:au_root
     if (!$root) { $root = $pwd }
 
-    Get-ChildItem $root\*\update.ps1 | ForEach-Object {
+    Get-ChildItem ([System.IO.Path]::Combine($root, '*', 'update.ps1')) | ForEach-Object {
         $packageDir = Get-Item (Split-Path $_)
 
         if ($Name -and $Name.Length -gt 0) {

--- a/AU/Public/Get-RemoteFiles.ps1
+++ b/AU/Public/Get-RemoteFiles.ps1
@@ -58,7 +58,8 @@ function Get-RemoteFiles {
 
     if ($Purge) {
         Write-Host 'Purging' $ext
-        Remove-Item -Force "$toolsPath\*.$ext" -ea ignore
+        $purgePath = "$toolsPath{0}*.$ext" -f [IO.Path]::DirectorySeparatorChar
+        Remove-Item -Force $purgePath -ea ignore
     }
 
     function headers($client) {
@@ -74,7 +75,7 @@ function Get-RemoteFiles {
             headers($client)
             $base_name = name4url $Latest.Url32
             $file_name = "{0}{2}.{1}" -f $base_name, $ext, $(if ($NoSuffix) { '' } else {'_x32'})
-            $file_path = "$toolsPath\$file_name"
+            $file_path = Join-Path $toolsPath $file_name
 
             Write-Host "Downloading to $file_name -" $Latest.Url32
             $client.DownloadFile($Latest.URL32, $file_path)
@@ -87,7 +88,7 @@ function Get-RemoteFiles {
             headers($client)
             $base_name = name4url $Latest.Url64
             $file_name = "{0}{2}.{1}" -f $base_name, $ext, $(if ($NoSuffix) { '' } else {'_x64'})
-            $file_path = "$toolsPath\$file_name"
+            $file_path = Join-Path $toolsPath $file_name
 
             Write-Host "Downloading to $file_name -" $Latest.Url64
             $client.DownloadFile($Latest.URL64, $file_path)

--- a/AU/Public/Push-Package.ps1
+++ b/AU/Public/Push-Package.ps1
@@ -14,7 +14,7 @@ function Push-Package() {
         [switch] $All
     )
     $api_key =  if (Test-Path api_key) { Get-Content api_key }
-                elseif (Test-Path ..\api_key) { Get-Content ..\api_key }
+                elseif (Test-Path (Join-Path '..' 'api_key')) { Get-Content (Join-Path '..' 'api_key') }
                 elseif ($Env:api_key) { $Env:api_key }
 
     $push_url =  if ($Env:au_PushUrl) { $Env:au_PushUrl }

--- a/AU/Public/Test-Package.ps1
+++ b/AU/Public/Test-Package.ps1
@@ -65,7 +65,7 @@ function Test-Package {
         Write-Host "Nuspec file given, running choco pack"
         choco pack -r $Nu.FullName --OutputDirectory $Nu.DirectoryName | Write-Host
         if ($LASTEXITCODE -ne 0) { throw "choco pack failed with $LastExitCode"}
-        $Nu = Get-Item "$($Nu.DirectoryName)\*.nupkg" | Sort-Object -Property CreationTime -Descending | Select-Object -First 1
+        $Nu = Get-Item ([System.IO.Path]::Combine($Nu.DirectoryName, '*.nupkg')) | Sort-Object -Property CreationTime -Descending | Select-Object -First 1
     } elseif ($Nu.Extension -ne '.nupkg') { throw "File is not nupkg or nuspec file" }
 
     #At this point Nu is nupkg file
@@ -85,13 +85,13 @@ function Test-Package {
 
         if (!$VagrantNoClear)  {
             Write-Host 'Removing existing vagrant packages'
-            Remove-Item $Vagrant\packages\*.nupkg -ea ignore
-            Remove-Item $Vagrant\packages\*.xml   -ea ignore
+            Remove-Item ([System.IO.Path]::Combine($Vagrant, 'packages', '*.nupkg')) -ea ignore
+            Remove-Item ([System.IO.Path]::Combine($Vagrant, 'packages', '*.xml'))   -ea ignore
         }
 
-        Copy-Item $Nu $Vagrant\packages
+        Copy-Item $Nu (Join-Path $Vagrant 'packages')
         $options_file = "$package_name.$package_version.xml"
-        @{ Install = $Install; Uninstall = $Uninstall; Parameters = $Parameters } | Export-CliXML "$Vagrant\packages\$options_file"
+        @{ Install = $Install; Uninstall = $Uninstall; Parameters = $Parameters } | Export-CliXML ([System.IO.Path]::Combine($Vagrant, 'packages', $options_file))
         if ($VagrantOpen) {
             Start-Process powershell -Verb Open -ArgumentList "-NoProfile -NoExit -Command `$Env:http_proxy=`$Env:https_proxy=`$Env:ftp_proxy=`$Env:no_proxy=''; cd $Vagrant; vagrant up"
         } else {

--- a/AU/Public/Update-Package.ps1
+++ b/AU/Public/Update-Package.ps1
@@ -250,7 +250,7 @@ function Update-Package {
         if ($WhatIf) { $package.Backup() }
         try {
             if (Test-Path Function:\au_BeforeUpdate) { 'Running au_BeforeUpdate' | result; au_BeforeUpdate $package | result }
-            if (!$NoReadme -and (Test-Path "$($package.Path)\README.md")) { Set-DescriptionFromReadme $package -SkipFirst 2 | result }        
+            if (!$NoReadme -and (Test-Path (Join-Path $package.Path 'README.md'))) { Set-DescriptionFromReadme $package -SkipFirst 2 | result }        
             update_files
             if (Test-Path Function:\au_AfterUpdate) { 'Running au_AfterUpdate' | result; au_AfterUpdate $package | result }
         


### PR DESCRIPTION
This does not get everything, specifically, I did not touch the tests, or the automatic checksumming section. 

For the automatic checksumming, I am kind of in favor of putting a check for non-windows, telling people to use Get-RemoteChecksum or embed, then throwing. 

Also, `$ENV:Temp` does not exist on Linux, so I switched that to  `[System.IO.Path]::GetTempPath()`.

Part of #234 