### PR TITLE
Add force push support and switch cpush to choco push

### DIFF
--- a/AU/Public/Push-Package.ps1
+++ b/AU/Public/Push-Package.ps1
@@ -19,13 +19,16 @@ function Push-Package() {
 
     $push_url =  if ($Env:au_PushUrl) { $Env:au_PushUrl }
                  else { 'https://push.chocolatey.org' }
+                 
+    $force_push = if ($Env:au_ForcePush) { '--force' }
+                  else { '' }
 
     $packages = Get-ChildItem *.nupkg | Sort-Object -Property CreationTime -Descending
     if (!$All) { $packages = $packages | Select-Object -First 1 }
     if (!$packages) { throw 'There is no nupkg file in the directory'}
     if ($api_key) {
-        $packages | ForEach-Object { cpush $_.Name --api-key $api_key --source $push_url }
+        $packages | ForEach-Object { cpush $_.Name --api-key $api_key --source $push_url $force_push }
     } else {
-        $packages | ForEach-Object { cpush $_.Name --source $push_url }
+        $packages | ForEach-Object { cpush $_.Name --source $push_url $force_push }
     }
 }

--- a/AU/Public/Push-Package.ps1
+++ b/AU/Public/Push-Package.ps1
@@ -27,8 +27,8 @@ function Push-Package() {
     if (!$All) { $packages = $packages | Select-Object -First 1 }
     if (!$packages) { throw 'There is no nupkg file in the directory'}
     if ($api_key) {
-        $packages | ForEach-Object { cpush $_.Name --api-key $api_key --source $push_url $force_push }
+        $packages | ForEach-Object { choco push $_.Name --api-key $api_key --source $push_url $force_push }
     } else {
-        $packages | ForEach-Object { cpush $_.Name --source $push_url $force_push }
+        $packages | ForEach-Object { choco push $_.Name --source $push_url $force_push }
     }
 }


### PR DESCRIPTION
Adds `$env:au_ForcePush` which will turn on `--force` for pushing, which allows pushing to insecure sources

Switches `cpush` to `choco push`, as `cpush` is not available (by default) on Linux