### PR TITLE
Replace rawgit links with jsdelivr

### DIFF
--- a/AU/Plugins/Report/markdown.ps1
+++ b/AU/Plugins/Report/markdown.ps1
@@ -15,8 +15,8 @@ $package_no      = $Info.result.all.Length
 
 $update_all_url  = if ($Github_UserRepo) {"https://github.com/$Github_UserRepo/blob/master/update_all.ps1" } else { "https://github.com/majkinetor/au-packages-template/blob/master/update_all.ps1" }
 
-$icon_ok = 'https://cdn.rawgit.com/majkinetor/au/master/AU/Plugins/Report/r_ok.png'
-$icon_er = 'https://cdn.rawgit.com/majkinetor/au/master/AU/Plugins/Report/r_er.png'
+$icon_ok = 'https://cdn.jsdelivr.net/gh/majkinetor/au@master/AU/Plugins/Report/r_ok.png'
+$icon_er = 'https://cdn.jsdelivr.net/gh/majkinetor/au@master/AU/Plugins/Report/r_er.png'
 
 "# $Title"
 


### PR DESCRIPTION
RawGit has reached the end of life quite some time ago and while these links *still* seem to work, they may not eventually.