### PR TITLE
fix package root url usage with Update-AUPackages

### DIFF
--- a/AU/Public/Update-Package.ps1
+++ b/AU/Public/Update-Package.ps1
@@ -225,7 +225,9 @@ function Update-Package {
         if ([AUVersion] $Latest.Version -gt [AUVersion] $Latest.NuspecVersion) {
             if (!($NoCheckChocoVersion -or $Force)) {
                 if ( !$au_GalleryPackageRootUrl ) { 
-                    $au_GalleryPackageRootUrl = if ($au_GalleryUrl) { "$au_GalleryUrl/packages" } else { 'https://chocolatey.org/packages' }
+                    $au_GalleryPackageRootUrl = if ($env:au_GalleryPackageRootUrl) { $env:au_GalleryPackageRootUrl } else { 
+                            if ($au_GalleryUrl) { "$au_GalleryUrl/packages" } else { 'https://chocolatey.org/packages' }
+                    }
                 }
                 $choco_url = "$au_GalleryPackageRootUrl/{0}/{1}" -f $global:Latest.PackageName, $package.RemoteVersion
                 try {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## NEXT
 
-- Added `$au_GalleryPackageRootUrl` as a slightly more flexible alternative to `$au_GalleryUrl` ([#250](https://github.com/majkinetor/au/pull/255))
-  - `$au_GalleryUrl` is still maintained for compatibility
+- Added `$au_GalleryPackageRootUrl` as a slightly more flexible alternative to `$au_GalleryUrl` ([#250](https://github.com/majkinetor/au/issues/250))
+  - `$au_GalleryUrl` global variable is still maintained for compatibility
+  - Can specify as an environment variable $env:au_GalleryPackageRootUrl when working with Update-AUPackages (update_all.ps1) ([#254](https://github.com/majkinetor/au/issues/254))
+  - Can specify as a global variable in update.ps1 to override on per package basis.
 
 ## 2021.7.18
 

--- a/README.md
+++ b/README.md
@@ -284,9 +284,12 @@ This is the same as if you added the parameters to `update` function inside the 
 
 however, its way easier to setup global variable with manual intervention on multiple packages.
 
-There is also a special variable `$au_GalleryPackageRootUrl` that can be added to `update.ps1` to change the URL that is used to check if package is already pushed. It defaults to `https://chocolatey.org/packages` and you can change it if you need this option for 3rd party or internal package repositories.
+There is also a special variable `$au_GalleryPackageRootUrl` that can be added to `update.ps1` to change the URL that is used to check if package is already pushed. It defaults to `https://chocolatey.org/packages`, but you can change it if you need this option for 3rd party or internal package repositories.
 
-> Note: The `$au_GalleryUrl` variable also performs this function, but `$au_GalleryPackageRootUrl` allows more flexibility for 3rd party package repositories.  The `$au_GalleryUrl` will still work for compatibility, but makes assumptions about the URL that may not work in all situations.  
+* When updating all packages, `Update-AUPackages` (alias `updateall`), you should specify it as an environment variable.
+* When adding to `update.ps1` you can specify it as a global variable, and it will override the environment setting.
+
+> Note: The `$au_GalleryUrl` global variable also performs this function, but `$au_GalleryPackageRootUrl` allows more flexibility for internal and 3rd party package repositories.  The `$au_GalleryUrl` will still work for compatibility, but makes assumptions about the URL that may not work in all situations.  
 
 ### Reusing the AU updater with metapackages
 


### PR DESCRIPTION
closes #254

This change would allow $au_GalleryPackageRootUrl to be specified as an environment variable.  (This determines where AU checks the remote version.)
By using an environment variable, we don't have to specify a global variable in every package's update.ps1 script.  However global variable would still work in the update.ps1.